### PR TITLE
Add support for GUI from container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,10 +41,11 @@
 
 	"mounts": [
 		"source=stafl-devcontainer-data,target=/home/vscode,type=volume",
-		"source=/mnt/wslg,target=/mnt/wslg,type=bind",
-		"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind"
+		"source=/mnt/wslg,target=/mnt/wslg,type=bind", // comment out if not on Windows 11
+		"source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind" // comment out if not on Windows 11
 	],
 
+	// comment out if not on Windows 11
 	"containerEnv": {
 		"DISPLAY": ":0",
 		"PULSE_SERVER": "/mnt/wslg/PulseServer",


### PR DESCRIPTION
Requires Windows 11 and VSCode setting
`Remote -> Containers -> Execute in WSL` to be enabled.