### PR TITLE
B2KP-112 Update Kroki container version.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,19 +4,12 @@ services:
   stafl-devcontainer:
     image: "ghcr.io/staflsystems/stafl-devcontainer-ci:latest"
     command: sleep infinity
-    network_mode: service:kroki
     volumes:
       - ..:/workspaces:cached
       - data:/home/vscode
   kroki:
-    image: yuzutech/kroki:latest
-    ports:
-      - 8000:8000
+    image: ghcr.io/staflsystems/kroki:latest
 
 volumes:
   data:
     name: stafl-devcontainer-data
-
-
-
-    


### PR DESCRIPTION
Update Kroki container version to custom build incorporating https://github.com/yuzutech/kroki/pull/1705.

We can switch back to an official build once a new release is out.