### PR TITLE
Add ARM build and update JLink + Structurizr. +semver:minor

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -2,14 +2,23 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: ['main']
-  pull_request:  
+    branches: [main]
+  pull_request:
+    types: [
+        opened,
+        synchronize,
+        reopened,
+      ]
+
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}-${{ github.ref == 'refs/heads/main' && github.sha || ''}}
+  cancel-in-progress: true
 
 env:
   DOCKER_IMAGE_NAME: ghcr.io/staflsystems/stafl-devcontainer-ci
   
 jobs:
-  push_to_registry:
+  build_and_push:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
     steps:
@@ -18,6 +27,10 @@ jobs:
         with:
           fetch-depth: 0
           lfs: true
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -43,6 +56,9 @@ jobs:
           context: ${{ github.workspace }}/stafl-devcontainer
           push: false
           tags: ghcr.io/staflsystems/stafl-devcontainer-ci
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Build and Push Docker image
         if: github.ref == 'refs/heads/main'
@@ -53,6 +69,9 @@ jobs:
           tags: | 
             ${{ env.DOCKER_IMAGE_NAME }}:latest
             ${{ env.DOCKER_IMAGE_NAME }}:${{ steps.staflversion.outputs.major }}.${{ steps.staflversion.outputs.minor }}.${{ steps.staflversion.outputs.patch }}-${{ steps.staflversion.outputs.build }}
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Create a GitHub release (main)
         if: github.ref == 'refs/heads/main'

--- a/stafl-devcontainer/Dockerfile
+++ b/stafl-devcontainer/Dockerfile
@@ -11,22 +11,21 @@ ADD user-setup-scripts /user-setup-scripts
 
 RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get -y install --no-install-recommends curl clang llvm-14 clang-format-14 doxygen g++ lcov gdb ninja-build wget bzip2 python2.7-dev python3 python3-pip python3-dev python3.10-venv gcc-multilib-mips-linux-gnu gcc-mips-linux-gnu g++-mips-linux-gnu qemu-user libncurses5 graphviz plantuml make software-properties-common udev ksh ripgrep bash-completion ca-certificates curl gnupg dos2unix openjdk-17-jdk \
+  && apt-get -y install --no-install-recommends bash-completion bzip2 ca-certificates clang clang-format-14 curl curl \ 
+     dos2unix doxygen g++ g++-mips-linux-gnu gcc-mips-linux-gnu gcc-multilib-mips-linux-gnu gdb gdb-multiarch git git-lfs \
+     gnupg graphviz inetutils-ping ksh lcov libncurses5 llvm-14 make ninja-build openjdk-17-jdk plantuml python2.7-dev python3 python3-dev \
+     python3-pip python3.10-venv qemu-user ripgrep software-properties-common udev wget \
   && find -path '/user-setup-scripts/*' | xargs dos2unix \
   && pip install cmake \
   && ln -s /usr/bin/llvm-cov-14 /usr/bin/llvm-cov \
   && ln -s /usr/bin/llvm-profdata-14 /usr/bin/llvm-profdata \
-  && add-apt-repository -y -n ppa:mozillateam/ppa \
   && add-apt-repository -y -n ppa:saiarcot895/chromium-beta \
-  && cat /user-setup-scripts/firefox/firefox-pin.txt > /etc/apt/preferences.d/mozilla-firefox \
-  && echo 'Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${VARIANT}";' > /etc/apt/apt.conf.d/51unattended-upgrades-firefox \
   && sudo mkdir -p /etc/apt/keyrings \ 
   && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
-  && add-apt-repository -y -n ppa:git-core/ppa \
-  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | sudo bash \
+  && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \ 
+    | sudo tee /etc/apt/sources.list.d/nodesource.list \
   && apt-get update \
-  && apt-get -y install --no-install-recommends git git-lfs nodejs firefox chromium-browser \
+  && apt-get -y install --no-install-recommends nodejs chromium-browser \
   && npm install -g https://github.com/maphstr/mdpdf.git \
   && npm install -g @withgraphite/graphite-cli@stable
 
@@ -37,7 +36,8 @@ RUN case ${TARGETPLATFORM} in \
   "linux/amd64") GCC_ARM_ARCH=x86_64  ;; \
   "linux/arm64") GCC_ARM_ARCH=aarch64 ;; \
   esac \
-  && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-$GCC_ARM_ARCH-linux.tar.bz2 -O gcc-arm-none-eabi.tar.bz2 \
+  && wget -q https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-$GCC_ARM_ARCH-linux.tar.bz2 \
+   -O gcc-arm-none-eabi.tar.bz2 \
   && tar -xjf gcc-arm-none-eabi.tar.bz2 \
   && rm gcc-arm-none-eabi.tar.bz2 \
   && mv gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb-non-py \
@@ -46,7 +46,8 @@ RUN case ${TARGETPLATFORM} in \
 # # Install TI CGT ARM
 RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
   echo "Installing TI CGT TMS470" \
-  && wget -q https://software-dl.ti.com/codegen/esd/cgt_public_sw/TMS470/20.2.5.LTS/ti_cgt_tms470_20.2.5.LTS_linux-x64_installer.bin -O ti-cgt-installer.bin \
+  && wget -q https://software-dl.ti.com/codegen/esd/cgt_public_sw/TMS470/20.2.5.LTS/ti_cgt_tms470_20.2.5.LTS_linux-x64_installer.bin \
+   -O ti-cgt-installer.bin \
   && chmod +x ti-cgt-installer.bin \
   && ./ti-cgt-installer.bin --mode=unattended --prefix /opt/ti-cgt-arm \
   && rm ti-cgt-installer.bin \
@@ -63,8 +64,8 @@ WORKDIR /
 
 #### Install jlink ####
 # URLs copied from https://www.segger.com/downloads/jlink/
-ARG JLINK_URL_x86_64="https://www.segger.com/downloads/jlink/JLink_Linux_V792_x86_64.deb"
-ARG JLINK_URL_ARM="https://www.segger.com/downloads/jlink/JLink_Linux_V792_arm64.deb"
+ARG JLINK_URL_x86_64="https://www.segger.com/downloads/jlink/JLink_Linux_V796e_x86_64.deb"
+ARG JLINK_URL_ARM="https://www.segger.com/downloads/jlink/JLink_Linux_V796e_arm64.deb"
 
 RUN case ${TARGETPLATFORM} in \
   "linux/amd64") JLINK_URL=$JLINK_URL_x86_64 ;; \
@@ -72,7 +73,7 @@ RUN case ${TARGETPLATFORM} in \
   esac \
   && sudo wget -q "$JLINK_URL" --post-data="accept_license_agreement=accepted" -O ./jlink_install.deb \
   && sudo /lib/systemd/systemd-udevd --daemon \
-  && sudo apt install -y ./jlink_install.deb \
+  && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends ./jlink_install.deb \
   && rm ./jlink_install.deb
 
 # Install SafeRTOS JLink plug-in
@@ -80,9 +81,11 @@ ADD utilities/RTOSPlugin_SafeRTOS_ubuntu-latest.so /opt/stafl-systems/RTOSPlugin
 RUN chmod +x /opt/stafl-systems/RTOSPlugin_SafeRTOS_ubuntu-latest.so
 
 # Install structurizr-cli
-ARG STRUCTURIZR_CLI_URL="https://github.com/structurizr/cli/releases/download/v1.35.0/structurizr-cli-1.35.0.zip"
+ARG STRUCTURIZR_CLI_URL="https://github.com/structurizr/cli/releases/download/v2024.03.03/structurizr-cli.zip"
 RUN sudo wget -q "${STRUCTURIZR_CLI_URL}" -O ./structurizr.zip \
-    && sudo unzip structurizr.zip -d /usr/bin/structurizr  \
-    && sudo ln -s /usr/bin/structurizr/structurizr.sh /usr/bin/structurizr/structurizr \
-    && PATH=/usr/bin/structurizr:$PATH \ 
+    && sudo unzip structurizr.zip -d /opt/structurizr  \
+    && sudo mkdir -p /usr/bin/structurizr \
+    && sudo ln -s /opt/structurizr/structurizr.sh /opt/structurizr/structurizr \
+    && sudo ln -s /opt/structurizr/structurizr.sh /usr/bin/structurizr/structurizr \
     && sudo rm structurizr.zip
+  


### PR DESCRIPTION
Changes:
- Remove Firefox (the VSCode Live Preview extension works better, Chromium is required for Markdown -> PDF conversions)
- Install Git and Git LFS through the standard Ubuntu update sites.
- Add ARM64 container build
- Enable docker build caching
- Update JLink to v7.96e
- Update Structurizr
  - Install structurizr to `/opt` instead of `/usr/bin`
  - A symlink to `/usr/bin/structurizr/structurizr` is still added for compatibility.
- Implement latest Graphite GitHub configuration guidelines.
- Sort apt dependencies alphabetically.


