### PR TITLE
B2KP-56 Add GCC ARM 13.3 Rel 1

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -20,7 +20,7 @@ env:
 jobs:
   build_and_push:
     name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-medium
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4

--- a/stafl-devcontainer/Dockerfile
+++ b/stafl-devcontainer/Dockerfile
@@ -31,7 +31,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 
 WORKDIR /opt
 
-# Install GCC ARM
+# Install GCC ARM 10.3
 RUN case ${TARGETPLATFORM} in \
   "linux/amd64") GCC_ARM_ARCH=x86_64  ;; \
   "linux/arm64") GCC_ARM_ARCH=aarch64 ;; \
@@ -42,6 +42,19 @@ RUN case ${TARGETPLATFORM} in \
   && rm gcc-arm-none-eabi.tar.bz2 \
   && mv gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb-non-py \
   && ln -s /opt/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb-py /opt/gcc-arm-none-eabi-10.3-2021.10/bin/arm-none-eabi-gdb
+
+# Install GCC ARM 13.3 Rel 1
+RUN case ${TARGETPLATFORM} in \
+  "linux/amd64") GCC_ARM_ARCH=x86_64  ;; \
+  "linux/arm64") GCC_ARM_ARCH=aarch64 ;; \
+  esac \
+  && wget -q https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-$GCC_ARM_ARCH-arm-none-eabi.tar.xz \
+   -O gcc-arm-none-eabi.tar.xz \
+  && tar -xf gcc-arm-none-eabi.tar.xz \
+  && rm gcc-arm-none-eabi.tar.xz \
+  && mv arm-gnu-toolchain-13.3.rel1-${GCC_ARM_ARCH}-arm-none-eabi gcc-arm-none-eabi-13.3.rel1 \
+  && mv gcc-arm-none-eabi-13.3.rel1/bin/arm-none-eabi-gdb gcc-arm-none-eabi-13.3.rel1/bin/arm-none-eabi-gdb-non-py \
+  && ln -s /opt/gcc-arm-none-eabi-13.3.rel1/bin/arm-none-eabi-gdb-py /opt/gcc-arm-none-eabi-13.3.rel1/bin/arm-none-eabi-gdb
 
 # # Install TI CGT ARM
 RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
@@ -58,7 +71,7 @@ RUN if [ "$TARGETPLATFORM" != "linux/arm64" ]; then \
   fi
 
 # Allow opt dir to be written
-RUN chmod -R -v 777 /opt
+RUN chmod -R 777 /opt
 
 WORKDIR /
 


### PR DESCRIPTION
Add GCC 13.3 Rel 1 to devcontainer.

This resolves a bug we recently ran into with GCC 10.3.

GCC 10.3 is being left in the image for now so that repositories can switch over incrementally.