### PR TITLE
B2KP-367 J-Link Flashing Issue Fix (hopefully) +semver:patch

### DIFF
--- a/stafl-devcontainer/Dockerfile
+++ b/stafl-devcontainer/Dockerfile
@@ -77,8 +77,8 @@ WORKDIR /
 
 #### Install jlink ####
 # URLs copied from https://www.segger.com/downloads/jlink/
-ARG JLINK_URL_x86_64="https://www.segger.com/downloads/jlink/JLink_Linux_V796e_x86_64.deb"
-ARG JLINK_URL_ARM="https://www.segger.com/downloads/jlink/JLink_Linux_V796e_arm64.deb"
+ARG JLINK_URL_x86_64="https://www.segger.com/downloads/jlink/JLink_Linux_V798i_x86_64.deb"
+ARG JLINK_URL_ARM="https://www.segger.com/downloads/jlink/JLink_Linux_V798i_arm64.deb"
 
 RUN case ${TARGETPLATFORM} in \
   "linux/amd64") JLINK_URL=$JLINK_URL_x86_64 ;; \


### PR DESCRIPTION
Update the J-Link software tools version. This seems to fix the failures to flash. They mention it in their release notes but the use case isn't _obviously_ the same as ours:

>NXP S32K3xx: In multi-core setups with multiple sessions to different cores involved, flash programming could fail with "Failed to preserve target RAM @ 0x20000000-0x20007FFF" error. Fixed.