### PR TITLE
B2KP-400 Update JLink SafeRTOS plugin +semver:patch

### DIFF
--- a/stafl-devcontainer/utilities/RTOSPlugin_SafeRTOS_ubuntu-latest.so
+++ b/stafl-devcontainer/utilities/RTOSPlugin_SafeRTOS_ubuntu-latest.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01ee163cd361dd4ef3dcef67f96ebb7cf2ea27262fbfbd348242eb49ac19aa1d
-size 21376
+oid sha256:7bf424950a3304d7d135057845784c8b8f1b1a25eed2740bc0e5bd4b24a9bdf0
+size 21360


### PR DESCRIPTION
Update to latest J-Link SafeRTOS plugin, adding support for more than 6 priorities. See also https://github.com/StaflSystems/stafl-jlink-safertos-plugin/commit/bdae86bbc3548edc17641cebae92c8896c6fb0bb.